### PR TITLE
Move to automatic core pools list in bal_addresses

### DIFF
--- a/fee_allocator/config_file.py
+++ b/fee_allocator/config_file.py
@@ -13,7 +13,7 @@ FEES_CONSTANTS = requests.get(
 ).json()
 
 CORE_POOLS = requests.get(
-    "https://raw.githubusercontent.com/BalancerMaxis/multisig-ops/main/config/core_pools.json"
+    "https://raw.githubusercontent.com/BalancerMaxis/bal_addresses/main/outputs/core_pools.json"
 ).json()
 
 REROUTE_CONFIG = requests.get(


### PR DESCRIPTION
This change moves from using the static core pools list in multisig ops, to the new dynamically generated one in bal_addresses that @gosuto-inzasheru just finished testing in this pr: https://github.com/BalancerMaxis/bal_addresses/pull/177

Once this is merged and has run once, we will no longer need to maintain a core pools list.   There is now a whitelist that can be used to add pools that are not showing up otherwise here:

https://github.com/BalancerMaxis/bal_addresses/blob/main/config/core_pools_whitelist.json