### PR TITLE
round all amounts down to the nearest cent 

### DIFF
--- a/fee_allocator/fees_collected/fees_2024-01-18_2024-02-01.json
+++ b/fee_allocator/fees_collected/fees_2024-01-18_2024-02-01.json
@@ -1,9 +1,9 @@
 {
-    "mainnet": 148028.8463,
-    "arbitrum": 80013.4232,
-    "polygon": 23199.86328,
-    "base": 2437.970503,
-    "gnosis": 20680.30342,
-    "avalanche": 46856.05693,
+    "mainnet": 148028.84,
+    "arbitrum": 80013.42,
+    "polygon": 23199.86,
+    "base": 2437.97,
+    "gnosis": 20680.30,
+    "avalanche": 46856.05,
     "zkevm": 0
 }


### PR DESCRIPTION
to prevent rounding something pp and spending more money than we have.