### PR TITLE
feat: remove need for changing timestamp constant

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ def main() -> None:
     # Get from input params or use default
     ts_now = parser.parse_args().ts_now or TS_NOW
     ts_in_the_past = parser.parse_args().ts_in_the_past or TS_2_WEEKS_AGO
-    print(f"\n\nRunning  from timestamps {ts_in_the_past} to {ts_now}")
+    print(f"\n\n\n------\nRunning  from timestamps {ts_in_the_past} to {ts_now}\n------\n\n\n")
     output_file_name = parser.parse_args().output_file_name or "current_fees.csv"
     fees_file_name = parser.parse_args().fees_file_name or "current_fees_collected.json"
     fees_path = os.path.join(ROOT, "fee_allocator", "fees_collected", fees_file_name)

--- a/main.py
+++ b/main.py
@@ -31,16 +31,16 @@ def get_last_thursday_odd_week():
     timedelta_to_last_thursday = timedelta(days=days_until_thursday + 7 * weeks_until_next_odd_week)
 
     # Calculate the timestamp of the last Thursday at 00:00 UTC
-    last_thursday_timestamp = (current_datetime - timedelta_to_last_thursday).replace(hour=0, minute=0, second=0, microsecond=0)
+    last_thursday_odd_utc = (current_datetime - timedelta_to_last_thursday).replace(hour=0, minute=0, second=0, microsecond=0)
 
-    return last_thursday_timestamp.timestamp()
+    return last_thursday_odd_utc
 
 now = datetime.utcnow()
 DELTA = 1000
 # TS_NOW = 1704326400
 # TS_2_WEEKS_AGO = 1703116800
 TS_NOW = int(now.timestamp()) - DELTA
-TS_2_WEEKS_AGO = get_last_thursday_odd_week().timestamp()
+TS_2_WEEKS_AGO = int(get_last_thursday_odd_week().timestamp())
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--ts_now", help="Current timestamp", type=int, required=False)

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ DELTA = 1000
 # TS_NOW = 1704326400
 # TS_2_WEEKS_AGO = 1703116800
 TS_NOW = int(now.timestamp()) - DELTA
-TS_2_WEEKS_AGO = get_last_thursday_odd_week()
+TS_2_WEEKS_AGO = get_last_thursday_odd_week().timestamp()
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--ts_now", help="Current timestamp", type=int, required=False)


### PR DESCRIPTION
Automatically determine the timestamp used when nothing is provided to give us the current epoch without regular updates of a constant.