### PR TITLE
fix: skip chain if fees <= 0

### DIFF
--- a/fee_allocator/accounting/fee_pipeline.py
+++ b/fee_allocator/accounting/fee_pipeline.py
@@ -28,12 +28,12 @@ from fee_allocator.helpers import get_twap_bpt_price
 
 
 def run_fees(
-        web3_instances: Munch[Web3],
-        timestamp_now: int,
-        timestamp_2_weeks_ago: int,
-        output_file_name: str,
-        fees_to_distribute: dict,
-        mapped_pools_info: dict,
+    web3_instances: Munch[Web3],
+    timestamp_now: int,
+    timestamp_2_weeks_ago: int,
+    output_file_name: str,
+    fees_to_distribute: dict,
+    mapped_pools_info: dict,
 ) -> dict:
     """
     This function is used to run the fee allocation process
@@ -61,6 +61,10 @@ def run_fees(
     existing_aura_bribs: List[Dict] = fetch_hh_aura_bribs()
     # Collect all BPT prices:
     for chain in Chains:
+        # confirm fees for this chain are > 0
+        if Decimal(fees_to_distribute[chain.value]) <= 0:
+            continue
+
         pools = core_pools.get(chain.value, None)
         if pools is None:
             continue

--- a/fee_allocator/accounting/fee_pipeline.py
+++ b/fee_allocator/accounting/fee_pipeline.py
@@ -62,7 +62,10 @@ def run_fees(
     # Collect all BPT prices:
     for chain in Chains:
         # confirm fees for this chain are > 0
-        if Decimal(fees_to_distribute[chain.value]) <= 0:
+        try:
+            if Decimal(fees_to_distribute[chain.value]) <= 0:
+                continue
+        except KeyError:
             continue
 
         pools = core_pools.get(chain.value, None)

--- a/fee_allocator/accounting/fee_pipeline.py
+++ b/fee_allocator/accounting/fee_pipeline.py
@@ -64,8 +64,10 @@ def run_fees(
         # confirm fees for this chain are > 0
         try:
             if Decimal(fees_to_distribute[chain.value]) <= 0:
+                incentives[chain.value] = {}
                 continue
         except KeyError:
+            incentives[chain.value] = {}
             continue
 
         pools = core_pools.get(chain.value, None)


### PR DESCRIPTION
previous runs kept exiting prematurely due to the zkevm rpc having problems

zkevm fees were 0 anyway, so in that case it can just be skipped

see successful run: https://github.com/BalancerMaxis/protocol_fee_allocator/actions/runs/7919729124/job/21621164269