### PR TITLE
fix:  pandas version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ python-dotenv
 web3==6.9.0
 gql[requests]==3.4.1
 pycoingecko==3.1.0
-pandas==2.0.3
+pandas>2.0,<2.3
 simplejson==3.19.2
-git+https://github.com/BalancerMaxis/bal_addresses@0.9.4
-git+https://github.com/BalancerMaxis/bal_tools@v0.0.1
+git+https://github.com/BalancerMaxis/bal_addresses@0.9.5
+git+https://github.com/BalancerMaxis/bal_tools@v0.0.3


### PR DESCRIPTION
New python 3.10 borks on our pandas.  This version string is working in other repos.