### PR TITLE
fix: bump bal addresses and tools

### DIFF
--- a/fee_allocator/helpers.py
+++ b/fee_allocator/helpers.py
@@ -53,7 +53,7 @@ query {{
 """
 BAL_GQL_QUERY = """
 query {{
-  tokenGetPriceChartData(address:"{token_addr}", range: NINETY_DAY)   
+  tokenGetPriceChartData(address:"{token_addr}", range: NINETY_DAY)
    {{
     id
     price

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ gql[requests]==3.4.1
 pycoingecko==3.1.0
 pandas>2.0,<2.3
 simplejson==3.19.2
-git+https://github.com/BalancerMaxis/bal_addresses@0.9.5
-git+https://github.com/BalancerMaxis/bal_tools@v0.0.3
+git+https://github.com/BalancerMaxis/bal_addresses@0.9.7
+git+https://github.com/BalancerMaxis/bal_tools@v0.0.6


### PR DESCRIPTION
getting new blocks subgraphs urls wont work on the old versions, needs >=0.0.5 for tools