### PR TITLE
chore: bump bal addresses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ gql[requests]==3.4.1
 pycoingecko==3.1.0
 pandas>2.0,<2.3
 simplejson==3.19.2
-git+https://github.com/BalancerMaxis/bal_addresses@0.9.10
+git+https://github.com/BalancerMaxis/bal_addresses@0.9.11
 eth-typing<5.0.0


### PR DESCRIPTION
actions are running into issues with the base/block subgraphs, bumping bal addresses (and thus bal tools)

<img width="1141" alt="Screenshot 2024-11-28 at 12 24 32" src="https://github.com/user-attachments/assets/99a020fe-62be-4b0e-85c9-5bd6d6fb4d44">
