### PR TITLE
fix collect fees cron

### DIFF
--- a/fee_allocator/accounting/fee_pipeline.py
+++ b/fee_allocator/accounting/fee_pipeline.py
@@ -69,7 +69,7 @@ def run_fees(
         poolutil = BalPoolsGauges(chain.value)
         listed_core_pools = core_pools.get(chain.value, None)
         pools = {}
-        if listed_core_pools is None or not fees_to_distribute.get(chain.value):
+        if listed_core_pools is None or chain.value not in fees_to_distribute:
             continue
         ###  Remove any invalid core pools
         for pool_id, description in listed_core_pools.items():


### PR DESCRIPTION
fixes #327 - issue was that the fee json that the cron job used had fees with 0 values and existing logic would skip those. now chains will run regardless of value